### PR TITLE
Add carddav support (template) and optional callback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ Where
     * **keys** includes the key and the certificate for signing the configuration file. See [signing configuration](#signing-configuration) for details of this object
   * **callback** (*err*, *data*) is the callback function to run once the configuration is generated. *err* is an Error object that is returned if an error occurs. *data* is the signed DER file as Buffer object, store it as *name.mobileconfig* to use
 
+### Generate and sign CardDAV configuration
+
+Generate and sign CardDAV configuration with
+
+```javascript
+mobileconfig.getSignedCardDAVConfig(options, callback)
+```
+
+Where
+
+  * **options** is the options object for the account data with following properties
+    * **organization** is an optional name of the signing organization
+    * **identifier** is a reverse-DNS style identifier (eg. *com.example.myprofile*) for the profile
+    * **displayName** is an optional name for the profile
+    * **displayDescription** is a optional description for the profile
+    * **accountName** is an optional name for the CardDAV account
+    * **accountName** is an optional description for the CardDAV account
+    * **dav** is the dav server configuration with the following properties
+      * **hostname** is the hostname of the server
+      * **port** is an optional port number for the server (standard port is used if not set)
+      * **secure** is a boolean that indicates if the server should use TLS/SSL (true) or not (false) when connecting
+      * **principalurl** is an URL for the currently authenticated user’s principal resource on the server
+      * **username** is the username of the email account
+      * **password** is the password for the account
+  * **callback** (*err*, *data*) is the callback function to run once the configuration is generated. *err* is an Error object that is returned if an error occurs. *data* is the signed DER file as Buffer object, store it as *name.mobileconfig* to use
+
 ### Signing configuration
 
 Signing configuration object defines the signing process and includes the following properties
@@ -124,6 +150,17 @@ mobileconfig.getSignedEmailConfig(options, function(err, data){
 ![](https://cldup.com/UtMePZizvG.png)
 
 See full featured example [here](examples/imap.js)
+
+## Changelog
+
+#### 1.0.1
+
+* CardDAV template and signing methods
+* Optional callback for unsigned methods
+
+#### 1.0.0
+
+* Initial version
 
 ## License
 

--- a/examples/carddav.js
+++ b/examples/carddav.js
@@ -1,0 +1,39 @@
+'use strict';
+
+// Usage:
+// node carddav.js > contact.mobileconfig
+
+var mobileconfig = require('../index');
+var fs = require('fs');
+
+mobileconfig.getCardDAVConfig({
+    organization: 'My Company',
+    identifier: 'com.my.company',
+
+    displayName: 'My Contacts',
+    displayDescription: 'Install this profile to auto configure your contacts',
+
+    accountName: 'CardDAV Config',
+    accountDescription: 'Configure your contact list',
+
+    dav: {
+        hostname: 'http://localhost:8080',
+        port: 8080,
+        secure: false,
+        principalurl: 'http://localhost:8080/dav/username',
+        username: 'username@gmail.com',
+        password: 'mypass'
+    },
+
+    keys: {
+        key: fs.readFileSync(__dirname + '/../test/fixtures/key.pem'),
+        cert: fs.readFileSync(__dirname + '/../test/fixtures/cert.pem'),
+        ca: []
+    }
+}, function(err, data) {
+    if (err) {
+        process.stderr.write(err.stack);
+        return process.exit(1);
+    }
+    process.stdout.write(data);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobileconfig",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Create and sign iOS mobileconfig configuration files",
   "main": "index.js",
   "scripts": {

--- a/templates/carddav.plist
+++ b/templates/carddav.plist
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      {{#if accountDescription}}
+        <key>CardDAVAccountDescription</key>
+        <string>{{accountDescription}}</string>
+      {{/if}}
+
+      <key>CardDAVHostName</key>
+      <string>{{dav.hostname}}</string>
+
+      <key>CardDAVPort</key>
+      <integer>{{dav.port}}</integer>
+
+      <key>CardDAVPrincipalURL</key>
+      <string>{{dav.principalurl}}</string>
+
+      <key>CardDAVUseSSL</key>
+      {{#if dav.secure}}
+        <true/>
+      {{ else }}
+        <false/>
+      {{/if}}
+
+      <key>CardDAVUsername</key>
+      <string>{{dav.username}}</string>
+
+      <key>CardDAVPassword</key>
+      <string>{{dav.password}}</string>
+
+      <key>PayloadDescription</key>
+      <string>{{dav.username}} contacts</string>
+
+      <key>PayloadDisplayName</key>
+      <string>{{dav.username}} contacts</string>
+
+      <key>PayloadIdentifier</key>
+      <string>{{identifier}}</string>
+
+      {{#if organization}}
+        <key>PayloadOrganization</key>
+        <string>{{organization}}</string>
+      {{/if}}
+
+      <key>PayloadType</key>
+      <string>com.apple.carddav.account</string>
+
+      <key>PayloadUUID</key>
+      <string>{{contentUuid}}</string>
+
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+
+    </dict>
+  </array>
+
+  <key>PayloadDescription</key>
+  <string>{{#if displayDescription}}{{displayDescription}}{{else}}Install this profile to auto configure contacts for {{emailAddress}}.{{/if}}</string>
+
+  <key>PayloadDisplayName</key>
+  <string>{{displayName}}</string>
+
+  <key>PayloadIdentifier</key>
+  <string>{{identifier}}</string>
+
+  {{#if organization}}
+    <key>PayloadOrganization</key>
+    <string>{{organization}}</string>
+  {{/if}}
+
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+
+  <key>PayloadType</key>
+  <string>Configuration</string>
+
+  <key>PayloadUUID</key>
+  <string>{{plistUuid}}</string>
+
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/test/mobileconfig-unit.js
+++ b/test/mobileconfig-unit.js
@@ -179,4 +179,111 @@ describe('mobileconfig unit tests', function() {
         });
     });
 
+    describe('#getCardDAVConfig', function() {
+        it('should generate valid plist', function() {
+            var options = {
+                organization: 'My Company',
+                identifier: 'com.my.company',
+
+                displayName: 'My Contacts',
+                displayDescription: 'Install this profile to auto configure your contacts',
+
+                accountName: 'CardDAV Config',
+                accountDescription: 'Configure your contact list',
+
+                dav: {
+                    hostname: 'http://localhost:8080',
+                    port: 8080,
+                    secure: false,
+                    principalurl: 'http://localhost:8080/dav/username',
+                    username: 'username@gmail.com',
+                    password: 'mypass'
+                },
+
+                contentUuid: 'abcdef',
+                plistUuid: 'ghijklmn'
+            };
+
+            var emailConfig = plist.parse(mobileconfig.getCardDAVConfig(options));
+
+            expect(emailConfig).to.deep.equal({
+                PayloadContent: [{
+                    CardDAVAccountDescription: 'Configure your contact list',
+                    CardDAVPrincipalURL: 'http://localhost:8080/dav/username',
+                    CardDAVHostName: 'http://localhost:8080',
+                    CardDAVPort: 8080,
+                    CardDAVUseSSL: false,
+                    CardDAVUsername: 'username@gmail.com',
+                    CardDAVPassword: 'mypass',
+                    PayloadDescription: 'username@gmail.com contacts',
+                    PayloadDisplayName: 'username@gmail.com contacts',
+                    PayloadIdentifier: 'com.my.company',
+                    PayloadOrganization: 'My Company',
+                    PayloadType: 'com.apple.carddav.account',
+                    PayloadUUID: 'abcdef',
+                    PayloadVersion: 1
+                }],
+                PayloadDescription: 'Install this profile to auto configure your contacts',
+                PayloadDisplayName: 'My Contacts',
+                PayloadIdentifier: 'com.my.company',
+                PayloadOrganization: 'My Company',
+                PayloadRemovalDisallowed: false,
+                PayloadType: 'Configuration',
+                PayloadUUID: 'ghijklmn',
+                PayloadVersion: 1
+            });
+        });
+    });
+
+    describe('#getSignedEmailConfig', function() {
+        it('should not return an error', function(done) {
+            var options = {
+                emailAddress: 'my-email-address@gmail.com',
+
+                organization: 'My Company',
+                identifier: 'com.my.company',
+
+                displayName: 'My Gmail Account',
+                displayDescription: 'Install this profile to auto configure your Gmail account',
+
+                accountName: 'IMAP Config',
+                accountDescription: 'Configure your Gmail account',
+
+                imap: {
+                    hostname: 'imap.gmail.com',
+                    port: 993,
+                    secure: true,
+                    username: 'my-email-address@gmail.com',
+                    password: 'mypass'
+                },
+
+                smtp: {
+                    hostname: 'smtp.gmail.com',
+                    port: 587,
+                    secure: false,
+                    username: 'my-email-address@gmail.com',
+                    password: false // use the same password as for IMAP
+                },
+
+                contentUuid: 'abcdef',
+                plistUuid: 'ghijklmn',
+
+                keys: {
+                    key: fs.readFileSync(__dirname + '/fixtures/key.pem'),
+                    cert: fs.readFileSync(__dirname + '/fixtures/cert.pem'),
+                    hashAlg: 'sha256',
+                    sigAlg: 'SHA256withRSA',
+                    signingTime: false
+                }
+            };
+
+            mobileconfig.getSignedEmailConfig(options, function(err, data) {
+                expect(err).to.not.exist;
+                expect(data).to.exist;
+
+                done();
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
I think this PR is ready for battle :+1: Bumped it to version 1.0.1

Besides adding the template for CardDAV, I also added an optional callback so you can export the mobileconfig unsigned too.

CalDAV and all other configs aren't needed in my case, but can by added later by another PR I guess.

![img](http://38.media.tumblr.com/598da1f73be5f7551ceab18a6c5816d0/tumblr_njqhmpBoNI1tdy0nco1_r1_540.gif)

Let me know what you think.
